### PR TITLE
 Add an option for aligning scopes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ custom.success('Custom Success Log');
   <img alt="Default Loggers" src="media/override-defaults.png" width="65%">
 </div>
 
-The `options` object can hold any of the following attributes: `disabled`, `interactive`, `stream`, `scope` and `types`. 
+The `options` object can hold any of the following attributes: `disabled`, `interactive`, `stream`, `scope` and `types`.
 
 ##### `disabled`
 
@@ -202,6 +202,13 @@ Destination to which the data is written, can be a single valid [Writable stream
 - Type: `String` or `Array of Strings`
 
 Name of the scope the logger is reporting from.
+
+##### `alignScopes`
+
+- Type: `Boolean`
+- Default: `false`
+
+Align the scope names across multiple logger instances.
 
 ##### `types`
 
@@ -257,9 +264,9 @@ global.success('Hello from the global scope');
 function foo() {
   const outer = global.scope('outer', 'scope');
   outer.success('Hello from the outer scope');
-  
+
   setTimeout(() => {
-    const inner = outer.scope('inner', 'scope'); 
+    const inner = outer.scope('inner', 'scope');
     inner.success('Hello from the inner scope');
   }, 500);
 }
@@ -382,14 +389,14 @@ The following illustrates all the available options with their respective defaul
 - Type: `Boolean`
 - Default: `false`
 
-Display the arguments, which replace the placeholder tokens on string interpolation, colored. 
+Display the arguments, which replace the placeholder tokens on string interpolation, colored.
 
 ##### `displayScope`
 
 - Type: `Boolean`
 - Default: `true`
 
-Display the scope name of the logger. 
+Display the scope name of the logger.
 
 ##### `displayBadge`
 
@@ -403,7 +410,7 @@ Display the badge of the logger.
 - Type: `Boolean`
 - Default: `false`
 
-Display the current local date in `YYYY-MM-DD` format. 
+Display the current local date in `YYYY-MM-DD` format.
 
 ##### `displayFilename`
 
@@ -478,7 +485,7 @@ signale.config({
   displayFilename: true,
   displayTimestamp: true,
   displayDate: false
-}); 
+});
 
 signale.success('Hello from the Global scope');
 ```
@@ -487,7 +494,7 @@ signale.success('Hello from the Global scope');
   <img alt="Local Config" src="media/local-config.png" width="65%">
 </div>
 
-Also, scoped loggers can have their own independent configuration, overriding the one inherited by the parent instance or `package.json`. 
+Also, scoped loggers can have their own independent configuration, overriding the one inherited by the parent instance or `package.json`.
 
 ```js
 // foo.js
@@ -596,7 +603,7 @@ Can be one or more comma delimited strings.
 ```js
 const signale = require('signale');
 
-const foo = signale.scope('foo'); 
+const foo = signale.scope('foo');
 const fooBar = signale.scope('foo', 'bar');
 
 foo.success('foo');
@@ -613,7 +620,7 @@ Clears the scope name of the logger.
 ```js
 const signale = require('signale');
 
-const foo = signale.scope('foo'); 
+const foo = signale.scope('foo');
 
 foo.success('foo');
 //=> [foo] › ✔  success  foo
@@ -654,7 +661,7 @@ signale.success('Successful operations');
 
 Sets a timers and accepts an optional label. If none provided the timer will receive a unique label automatically.
 
-Returns a string corresponding to the timer label. 
+Returns a string corresponding to the timer label.
 
 ##### **`label`**
 

--- a/signale.js
+++ b/signale.js
@@ -117,7 +117,7 @@ class Signale {
   _formatScopeName() {
     if (Array.isArray(this._scopeName)) {
       const scopes = this._scopeName.filter(x => x.length !== 0);
-      return `${scopes.map(x => `[${x.trim()}]`).join(' ')}`;
+      return scopes.map(x => `[${x.trim()}]`).join(' ');
     }
     return `[${this._scopeName}]`;
   }

--- a/signale.js
+++ b/signale.js
@@ -115,11 +115,10 @@ class Signale {
   }
 
   _formatScopeName() {
-    if (Array.isArray(this._scopeName)) {
-      const scopes = this._scopeName.filter(x => x.length !== 0);
-      return scopes.map(x => `[${x.trim()}]`).join(' ');
-    }
-    return `[${this._scopeName}]`;
+    let scopeNames = Array.isArray(this._scopeName) ? this._scopeName : [this._scopeName];
+    scopeNames = scopeNames.filter(x => x.length !== 0);
+
+    return scopeNames.map(x => `[${x.trim()}]`).join(' ');
   }
 
   _formatTimestamp() {

--- a/signale.js
+++ b/signale.js
@@ -26,10 +26,14 @@ class Signale {
     this._customTypes = Object.assign({}, options.types);
     this._disabled = options.disabled || false;
     this._scopeName = options.scope || '';
+    this._alignScopes = options.alignScopes || false;
     this._timers = options.timers || new Map();
     this._types = this._mergeTypes(defaultTypes, this._customTypes);
     this._stream = options.stream || process.stdout;
     this._longestLabel = defaultTypes.start.label.length;
+
+    this.constructor._scopeNames = this.constructor._scopeNames || [];
+    this.constructor._scopeNames.push(this._scopeName);
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -114,8 +118,8 @@ class Signale {
     return `[${this.filename}]`;
   }
 
-  _formatScopeName() {
-    let scopeNames = Array.isArray(this._scopeName) ? this._scopeName : [this._scopeName];
+  _formatScopeName(scopeNames) {
+    scopeNames = Array.isArray(scopeNames) ? scopeNames : [scopeNames];
     scopeNames = scopeNames.filter(x => x.length !== 0);
 
     return scopeNames.map(x => `[${x.trim()}]`).join(' ');
@@ -155,7 +159,16 @@ class Signale {
       meta.push(this._formatFilename());
     }
     if (this._scopeName.length !== 0 && this._config.displayScope) {
-      meta.push(this._formatScopeName());
+      let scopeName = this._formatScopeName(this._scopeName);
+
+      if (this._alignScopes) {
+        const scopeLengths = this.constructor._scopeNames.map(scopeName => this._formatScopeName(scopeName).length);
+        const maxScopeLength = Math.max(...scopeLengths);
+
+        scopeName = scopeName.padEnd(maxScopeLength);
+      }
+
+      meta.push(scopeName);
     }
     if (meta.length !== 0) {
       meta.push(`${figures.pointerSmall}`);


### PR DESCRIPTION
Every time a new logger instance is created, it stores the scope(s) in a static (class) property. Then when the scopes are output, we can look through the array to find the longest scope(s) in order to figure out how much to pad the scope(s) by.

The alignment will happen on the “pointer”. So it will look something like this:

```
[first scope]  > output
[second scope] > output
```

#49