### PR TITLE
Included features from issue #56 - Global callback when log type is called

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,10 @@ const options = {
     remind: {
       badge: '**',
       color: 'yellow',
-      label: 'reminder'
+      label: 'reminder',
+      done: (...msg) => {
+        // Do something with the logged message(s)
+      }
     },
     santa: {
       badge: '🎅',

--- a/signale.js
+++ b/signale.js
@@ -263,7 +263,9 @@ class Signale {
 
   _logger(type, ...messageObj) {
     this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
-    if (this._types[type].done) this._types[type].done(...messageObj);
+    if (this._types[type].done) {
+      this._types[type].done(...messageObj);
+    }
   }
 
   _padEnd(str, targetLength) {

--- a/signale.js
+++ b/signale.js
@@ -263,6 +263,7 @@ class Signale {
 
   _logger(type, ...messageObj) {
     this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
+    if (this._types[type].done) this._types[type].done(...messageObj);
   }
 
   _padEnd(str, targetLength) {


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
This fixes issue #56 you can now set global callbacks for logs which will be called once the logger function is called. The callback function will get the exact same data which the user used. 
```js
const {Signale} = require('signale');

const options = {
  disabled: false,
  interactive: false,
  stream: process.stdout,
  scope: 'custom',
  types: {
    remind: {
      badge: '**',
      color: 'yellow',
      label: 'reminder',
      done: (...msg) => {
        // Do something with the logged message(s)
      }
    },
    santa: {
      badge: '🎅',
      color: 'red',
      label: 'santa'
    }
  }
};

const custom = new Signale(options);
custom.remind('Improve documentation.');
custom.santa('Hoho! You have an unused variable on L45.');
``` 
Calling `custom.remind('Hello', ', I love cookies')` will get passed to the `done` callback as `['Hello', ', I love cookies']`. You can then use it for whatever logging purposes.