### PR TITLE
Support passing in filter words

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Come over to [Gitter](https://gitter.im/klaussinani/signale) or [Twitter](https:
 - Simple and minimal syntax
 - Globally configurable through `package.json`
 - Overridable configuration per file and logger
-- The ability to blacklist words (to not leak secrets)
+- The ability to filter words (to not leak secrets)
 
 ## Contents
 
@@ -375,7 +375,7 @@ The following illustrates all the available options with their respective defaul
     "underlinePrefix": false,
     "underlineSuffix": false,
     "uppercaseLabel": false,
-    "blacklistWords": {}
+    "filterWords": {}
   }
 }
 ```
@@ -467,7 +467,7 @@ Underline the logger suffix.
 
 Display the label of the logger in uppercase.
 
-##### `blacklistWords`
+##### `filterWords`
 
 - Type: `Object`
 - Default: `{}`

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ Come over to [Gitter](https://gitter.im/klaussinani/signale) or [Twitter](https:
 - Simple and minimal syntax
 - Globally configurable through `package.json`
 - Overridable configuration per file and logger
+- The ability to blacklist words (to not leak secrets)
 
 ## Contents
 
@@ -373,7 +374,8 @@ The following illustrates all the available options with their respective defaul
     "underlineMessage": false,
     "underlinePrefix": false,
     "underlineSuffix": false,
-    "uppercaseLabel": false
+    "uppercaseLabel": false,
+    "blacklistWords": {}
   }
 }
 ```
@@ -464,6 +466,16 @@ Underline the logger suffix.
 - Default: `false`
 
 Display the label of the logger in uppercase.
+
+##### `blacklistWords`
+
+- Type: `Object`
+- Default: `{}`
+
+An object where the keys are replaced with the values, e.g.
+`{ foo: "[BAR]" }` where any time "foo" may be printed it would
+be replaced with "[BAR]".
+
 
 </details>
 

--- a/signale.js
+++ b/signale.js
@@ -24,6 +24,7 @@ class Signale {
     this._types = this._mergeTypes(defaultTypes, this._customTypes);
     this._stream = options.stream || process.stdout;
     this._longestLabel = this._getLongestLabel();
+    this._blacklistWords = options.blacklistWords || {};
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -45,7 +46,8 @@ class Signale {
       types: this._customTypes,
       interactive: this._interactive,
       timers: this._timers,
-      stream: this._stream
+      stream: this._stream,
+      blacklistWords: this._blacklistWords
     });
   }
 
@@ -243,13 +245,27 @@ class Signale {
     return signale.join(' ');
   }
 
+  _removeBlackListedWords(message) {
+    let wordsToRemove = Object.keys(this._blacklistWords);
+    if (wordsToRemove.length === 0) {
+      return message;
+    } else {
+      let filteredMessage = message;
+      wordsToRemove.forEach(word => {
+        filteredMessage = filteredMessage.replace(new RegExp(word), this._blacklistWords[word]);
+      })
+      return filteredMessage;
+    }
+  }
+
   _write(stream, message) {
     if (this._interactive && isPreviousLogInteractive) {
       stream.moveCursor(0, -1);
       stream.clearLine();
       stream.cursorTo(0);
     }
-    stream.write(message + '\n');
+    let safeMessage = this._removeBlackListedWords(message)
+    stream.write(safeMessage + '\n');
     isPreviousLogInteractive = this._interactive;
   }
 

--- a/signale.js
+++ b/signale.js
@@ -24,7 +24,7 @@ class Signale {
     this._types = this._mergeTypes(defaultTypes, this._customTypes);
     this._stream = options.stream || process.stdout;
     this._longestLabel = this._getLongestLabel();
-    this._blacklistWords = options.blacklistWords || {};
+    this._filterWords = options.filterWords || {};
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -47,7 +47,7 @@ class Signale {
       interactive: this._interactive,
       timers: this._timers,
       stream: this._stream,
-      blacklistWords: this._blacklistWords
+      filterWords: this._filterWords
     });
   }
 
@@ -245,17 +245,17 @@ class Signale {
     return signale.join(' ');
   }
 
-  _removeBlackListedWords(message) {
-    let wordsToRemove = Object.keys(this._blacklistWords);
+  _removeFilteredWords(message) {
+    const wordsToRemove = Object.keys(this._filterWords);
     if (wordsToRemove.length === 0) {
       return message;
-    } else {
-      let filteredMessage = message;
-      wordsToRemove.forEach(word => {
-        filteredMessage = filteredMessage.replace(new RegExp(word), this._blacklistWords[word]);
-      })
-      return filteredMessage;
     }
+
+    let filteredMessage = message;
+    wordsToRemove.forEach(word => {
+      filteredMessage = filteredMessage.replace(new RegExp(word), this._filterWords[word]);
+    });
+    return filteredMessage;
   }
 
   _write(stream, message) {
@@ -264,7 +264,7 @@ class Signale {
       stream.clearLine();
       stream.cursorTo(0);
     }
-    let safeMessage = this._removeBlackListedWords(message)
+    const safeMessage = this._removeFilteredWords(message);
     stream.write(safeMessage + '\n');
     isPreviousLogInteractive = this._interactive;
   }


### PR DESCRIPTION
Hi, this doesn't have a corresponding issue - I figured the implementation would be quick enough that it would take a similar amount of time. I'd like the ability to filter words in my logs. This is predominantly so that I can make sure that logs never leak ENV vars etc.

This is what the API & usage looks like:

```
~/d/p/o/j/signale  $ node 
> const {Signale} = require("./index")
undefined

> const logger = new Signale({ blacklistWords: { "123456": "[API_TOKEN]" } })
undefined

> logger.success("Not showing 123456")
✔  success   Not showing [API_TOKEN]
```

Does that seem reasonable?