### PR TITLE
Added new `wait` alias for `await` logger

### DIFF
--- a/types.js
+++ b/types.js
@@ -32,6 +32,11 @@ module.exports = {
     color: 'green',
     label: 'success'
   },
+  wait: {
+    badge: figures.ellipsis,
+    color: 'blue',
+    label: 'waiting'
+  },
   warn: {
     badge: figures.warning,
     color: 'yellow',


### PR DESCRIPTION
## Description

Due to the fact that `await` is a reserved keyword used exclusively under the scope of async functions, a new `wait` type logger is introduced by this PR, which will act as an alias/alternative. The main purpose for this addition is for the API to be in sync with the best possible practices design-wise and to prevent any possible inconveniences, _(not actual parsing or runtime errors)_, resulting from the usage a function named `await`, such as code linting errors, confusion during debugging or auditing etc. 

```js
// example.js
const {await} = require('signale');

await('Executing calculation...');
// Possible linting error: 'Can not use keyword await outside an async function'
```

The existing `await` logger will not be removed from the API for backwards compatibility reasons, but its usage will be discouraged and `wait` will be counter-proposed on the API docs.