### PR TITLE
fix repo badge pointing to old legacy repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 </div>
 
 <p align="center">
-  <a href="https://travis-ci.org/klaussinani/signale">
+  <a href="https://travis-ci.com/klaussinani/signale">
     <img alt="Build Status" src="https://travis-ci.com/klaussinani/signale.svg?branch=master">
   </a>
   <a href="https://www.npmjs.com/package/signale">


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Signale!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/signale/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

Thank you so much again for all of your time invested in the project!

-->
