### PR TITLE
Add support for secrets/sensitive-info filtering

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -24,6 +24,7 @@ class Signale {
     this._types = this._mergeTypes(defaultTypes, this._customTypes);
     this._stream = options.stream || process.stdout;
     this._longestLabel = this._getLongestLabel();
+    this._secrets = options.secrets || [];
 
     Object.keys(this._types).forEach(type => {
       this[type] = this._logger.bind(this, type);
@@ -45,7 +46,8 @@ class Signale {
       types: this._customTypes,
       interactive: this._interactive,
       timers: this._timers,
-      stream: this._stream
+      stream: this._stream,
+      secrets: this._secrets
     });
   }
 
@@ -106,6 +108,22 @@ class Signale {
     });
 
     return types;
+  }
+
+  _filterSecrets(message) {
+    const {_secrets} = this;
+
+    if (_secrets.length === 0) {
+      return message;
+    }
+
+    let safeMessage = message;
+
+    _secrets.forEach(secret => {
+      safeMessage = safeMessage.replace(new RegExp(secret, 'g'), '[secure]');
+    });
+
+    return safeMessage;
   }
 
   _formatStream(stream) {
@@ -255,7 +273,9 @@ class Signale {
   }
 
   _logger(type, ...messageObj) {
-    this._log(this._buildSignale(this._types[type], ...messageObj), this._types[type].stream);
+    const {stream} = this._types[type];
+    const message = this._buildSignale(this._types[type], ...messageObj);
+    this._log(this._filterSecrets(message), stream);
   }
 
   _padEnd(str, targetLength) {


### PR DESCRIPTION
## Description

The PR introduces the ability to filter out secrets/sensitive-info from the body & metadata, i.e. scope name etc, of to-be-logged messages. The feature can be utilized through the `secrets` option, which is part of the configuration object passed to a `Signale` instance on initialization. The option is of type `Array<String|Number>` and can hold multiple secrets, all of which are removed, if present, from the to-be-logged messages and replaced with the default `'[secure]'` string. Additionally, when the unary `signale.scope(name)` function is used, the returned `Signale` instance inherits all the secrets belonging to its parent. The secrets checking process is performed in a **case-sensitive** manner. Finally, this PR is a follow-up to #71.

It is **critical** and **highly recommended** to **not type directly secrets in your code**, thus the following example serves **only** as a simple & easily reproducible usage demonstration.

```js
// foo.js
'use strict';
const {Signale} = require('signale');

// In reality secrets could be securely fetched/decrypted through a dedicated API 
const [USERNAME, TOKEN] = ['klaussinani', 'token'];

const logger = new Signale({
  secrets: [USERNAME, TOKEN]
});

logger.log('$ export USERNAME=%s', USERNAME);
//=> $ export USERNAME=[secure]
logger.log('$ export TOKEN=%s', TOKEN);
//=> $ export TOKEN=[secure]

// `logger1` inherits all secrets from its parent `logger`
const logger1 = logger.scope('parent');

logger1.log('$ export USERNAME=%s', USERNAME);
//=> [parent] › $ export USERNAME=[secure]
logger1.log('$ export TOKEN=%s', TOKEN);
//=> [parent] › $ export TOKEN=[secure]
```