### PR TITLE
Add support for log levels. Fixes #51

### DIFF
--- a/types.js
+++ b/types.js
@@ -5,86 +5,103 @@ module.exports = {
   error: {
     badge: figures.cross,
     color: 'red',
-    label: 'error'
+    label: 'error',
+    logLevel: 'error'
   },
   fatal: {
     badge: figures.cross,
     color: 'red',
-    label: 'fatal'
+    label: 'fatal',
+    logLevel: 'error'
   },
   fav: {
     badge: figures('❤'),
     color: 'magenta',
-    label: 'favorite'
+    label: 'favorite',
+    logLevel: 'info'
   },
   info: {
     badge: figures.info,
     color: 'blue',
-    label: 'info'
+    label: 'info',
+    logLevel: 'info'
   },
   star: {
     badge: figures.star,
     color: 'yellow',
-    label: 'star'
+    label: 'star',
+    logLevel: 'info'
   },
   success: {
     badge: figures.tick,
     color: 'green',
-    label: 'success'
+    label: 'success',
+    logLevel: 'info'
   },
   wait: {
     badge: figures.ellipsis,
     color: 'blue',
-    label: 'waiting'
+    label: 'waiting',
+    logLevel: 'info'
   },
   warn: {
     badge: figures.warning,
     color: 'yellow',
-    label: 'warning'
+    label: 'warning',
+    logLevel: 'warn'
   },
   complete: {
     badge: figures.checkboxOn,
     color: 'cyan',
-    label: 'complete'
+    label: 'complete',
+    logLevel: 'info'
   },
   pending: {
     badge: figures.checkboxOff,
     color: 'magenta',
-    label: 'pending'
+    label: 'pending',
+    logLevel: 'info'
   },
   note: {
     badge: figures.bullet,
     color: 'blue',
-    label: 'note'
+    label: 'note',
+    logLevel: 'info'
   },
   start: {
     badge: figures.play,
     color: 'green',
-    label: 'start'
+    label: 'start',
+    logLevel: 'info'
   },
   pause: {
     badge: figures.squareSmallFilled,
     color: 'yellow',
-    label: 'pause'
+    label: 'pause',
+    logLevel: 'info'
   },
   debug: {
     badge: figures('⬤'),
     color: 'red',
-    label: 'debug'
+    label: 'debug',
+    logLevel: 'debug'
   },
   await: {
     badge: figures.ellipsis,
     color: 'blue',
-    label: 'awaiting'
+    label: 'awaiting',
+    logLevel: 'info'
   },
   watch: {
     badge: figures.ellipsis,
     color: 'yellow',
-    label: 'watching'
+    label: 'watching',
+    logLevel: 'info'
   },
   log: {
     badge: '',
     color: '',
-    label: ''
+    label: '',
+    logLevel: 'info'
   }
 };


### PR DESCRIPTION
## Description

The PR introduces the ability to display/hide logged messages through a scaled logging level system. The logging level can be defined through the `logLevel` option, which is of type `String` & it is part of the configuration object pass to the initialization of a `Signale` instance, and can be one of the following 5 strings:

- `'info'` - Displays all the messages of all logger types.
- `'timer'` - Displays only the messages of `time`, `timeEnd`, `debug`, `warn`, `error` & `fatal` logger types.
- `'debug'` - Displays only the messages of `debug`, `warn`, `error` & `fatal` logger types.
- `'warn'` - Displays only the messages of `warn`, `error` & `fatal` logger types.
- `'error'` - Displays only the messages of `error` & `fatal` logger types.

The **default** value is `'info'` for the `logLevel` Signale configuration option, as well as for the `logLevel` attribute of custom logger types. The option is inherited from parent to child instance whenever the unary `signale.scope()` function is used.

```js
const {Signale} = require('signale');

const signale = new Signale({
  scope: 'parent',
  logLevel: 'debug' // Only `debug`, `warn` & `error` messages will be logged
});

signale.info('Info message');
//=>
signale.time('timer');
//=>
signale.timeEnd('timer');
//=>
signale.debug('Debug message');
//=> [parent] › ⬤  debug     Debug message
signale.warn('Warn message');
//=> [parent] › ⚠  warning   Warn message
signale.error('Error message');
//=> [parent] › ✖  error     Error message

// `child` logger inherits the `debug` log level of its parent instance
const child = signale.scope('child');

child.info('Info message');
//=>
child.time('test');
//=>
child.timeEnd('test');
//=>
child.debug('Debug message');
//=> [child] › ⬤  debug     Debug message
child.warn('Warn message');
//=> [child] › ⚠  warning   Warn message
child.error('Error message');
//=> [child] › ✖  error     Error message
```