### PR TITLE
Enable interactive mode only on `tty.WriteStream` streams. Fixes #55

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -270,7 +270,7 @@ class Signale {
   }
 
   _write(stream, message) {
-    if (this._interactive && isPreviousLogInteractive) {
+    if (this._interactive && stream.isTTY && isPreviousLogInteractive) {
       stream.moveCursor(0, -1);
       stream.clearLine();
       stream.cursorTo(0);


### PR DESCRIPTION
## Description

The PR restricts the use of the **interactive mode** only on [`tty.WriteStream`](https://nodejs.org/api/tty.html#tty_class_tty_writestream) writable streams, due to the fact that the following functions, that are utilized by the mode, are unavailable on non-TTY writables, i.e. `fs.WriteStream` streams, IDE consoles etc:

- [`writeStream.clearLine(dir)`](https://nodejs.org/api/tty.html#tty_writestream_clearline_dir)
- [`writeStream.cursorTo(x, y)`](https://nodejs.org/api/tty.html#tty_writestream_cursorto_x_y)
- [`writeStream.moveCursor(dx, dy)`](https://nodejs.org/api/tty.html#tty_writestream_movecursor_dx_dy)

In the future, the above-described methods will be employed through the [`readline`](https://nodejs.org/api/readline.html#readline_readline) module API instead of the currently used [`tty`](https://nodejs.org/api/tty.html#tty_tty), due to the [**deprecated nature**](https://github.com/nodejs/node/blob/master/lib/tty.js#L129) of the last. 