### PR TITLE
Replace interactive mode `tty` API with `readline` (#82)

### DIFF
--- a/signale.js
+++ b/signale.js
@@ -1,6 +1,7 @@
 'use strict';
 const util = require('util');
 const path = require('path');
+const readline = require('readline');
 const chalk = require('chalk');
 const figures = require('figures');
 const pkgConf = require('pkg-conf');
@@ -271,9 +272,9 @@ class Signale {
 
   _write(stream, message) {
     if (this._interactive && stream.isTTY && isPreviousLogInteractive) {
-      stream.moveCursor(0, -1);
-      stream.clearLine();
-      stream.cursorTo(0);
+      readline.moveCursor(stream, 0, -1);
+      readline.clearLine(stream);
+      readline.cursorTo(stream, 0);
     }
 
     stream.write(message + '\n');


### PR DESCRIPTION
## Description

The PR replaces the function of **Group A**, originating from the [`tty.WriteStream`](https://nodejs.org/api/tty.html#tty_class_tty_writestream) API, which are used by the **interactive mode**, with the ones of **Group B**, originating from the  [`readline`](https://nodejs.org/api/readline.html#readline_readline) API, due to the [**deprecated nature**](https://github.com/nodejs/node/blob/master/lib/tty.js#L129) of the ones in the first group. 

#### Group A - `tty.WriteStream` API (old/depraceted)

- [`writeStream.clearLine(dir)`](https://nodejs.org/api/tty.html#tty_writestream_clearline_dir)
- [`writeStream.cursorTo(x, y)`](https://nodejs.org/api/tty.html#tty_writestream_cursorto_x_y)
- [`writeStream.moveCursor(dx, dy)`](https://nodejs.org/api/tty.html#tty_writestream_movecursor_dx_dy)


#### Group B - `readline` API (new)

- [`readline.clearLine(stream, dir)`](https://nodejs.org/api/readline.html#readline_readline_clearline_stream_dir)
- [`readline.cursorTo(stream, x, y)`](https://nodejs.org/api/readline.html#readline_readline_cursorto_stream_x_y)
- [`readline.moveCursor(stream, dx, dy)`](https://nodejs.org/api/readline.html#readline_readline_movecursor_stream_dx_dy)

#### Changes Overview

```diff
  _write(stream, message) {
    if (this._interactive && stream.isTTY && isPreviousLogInteractive) {
-      stream.moveCursor(0, -1);
-      stream.clearLine();
-      stream.cursorTo(0);
+      readline.moveCursor(stream, 0, -1);
+      readline.clearLine(stream);
+      readline.cursorTo(stream, 0);
    }
```