### PR TITLE
TypeScript: Included missing ambient type declarations

### DIFF
--- a/types/signale.d.ts
+++ b/types/signale.d.ts
@@ -4,7 +4,7 @@
  *          Klaus Sinani <https://github.com/klaussinani>
  */
 
-import {Writable as WritableStream} from 'stream';
+import { Writable as WritableStream } from 'stream';
 
 declare namespace _signale {
   export type DefaultLogger =
@@ -25,12 +25,36 @@ declare namespace _signale {
     | 'warn'
     | 'watch';
 
+  export type ChalkColor =
+    | 'black'
+    | 'blue'
+    | 'blueBright'
+    | 'cyan'
+    | 'cyanBright'
+    | 'gray'
+    | 'green'
+    | 'greenBright'
+    | 'magenta'
+    | 'magentaBright'
+    | 'red'
+    | 'redBright'
+    | 'white'
+    | 'whiteBright'
+    | 'yellow'
+    | 'yellowBright';
+
+  export type Secret = (string | number)[];
+
   export type LoggerFunction = (...message: any[]) => void;
+
+  export type LogLevel = 'info' | 'timer' | 'debug' | 'warn' | 'error';
 
   export interface LoggerConfiguration {
     badge: string;
-    color: string;
+    color: ChalkColor;
     label: string;
+    logLevel?: LogLevel;
+    stream?: WritableStream | WritableStream[];
   }
 
   export interface InstanceConfiguration {
@@ -51,7 +75,9 @@ declare namespace _signale {
     config?: InstanceConfiguration;
     disabled?: boolean;
     interactive?: boolean;
+    logLevel?: LogLevel;
     scope?: string;
+    secrets?: Secret;
     stream?: WritableStream | WritableStream[];
     types?: Partial<Record<T, LoggerConfiguration>>;
   }
@@ -63,11 +89,16 @@ declare namespace _signale {
   }
 
   interface Base<T extends string = DefaultLogger> {
+    addSecrets(secrets: Secret): void;
+    clearSecrets(): void;
     config(configObj: InstanceConfiguration): Instance<T>;
+    disable(): void;
+    enable(): void;
+    isEnabled(): boolean;
     scope(...name: string[]): Instance<T>;
-    unscope(): void;
     time(label?: string): string;
     timeEnd(label?: string): { label: string; span: number };
+    unscope(): void;
   }
 
   export type Instance<T extends string = DefaultLogger> = Base<T> &
@@ -76,6 +107,9 @@ declare namespace _signale {
 }
 
 declare namespace signale {
+  export type Secret = _signale.Secret;
+  export type LogLevel = _signale.LogLevel;
+  export type ChalkColor = _signale.ChalkColor;
   export type DefaultLogger = _signale.DefaultLogger;
   export type LoggerFunction = _signale.LoggerFunction;
   export interface SignaleConfiguration


### PR DESCRIPTION
## Description

The PR, a follow-up to #85, introduces the missing TS ambient type declaration for the Signale API.

- `addSecrets(secrets)`
- `clearSecrets()`
- `config(configObj)`
- `disable()`
- `enable()`
- `isEnabled()`

Additionally, adds the following 3 types to the exported `signale` namespace: 

- `ChalkColor`
- `Secret`
- `LogLevel`