### PR TITLE
TypeScript: Added ambient type declaration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "logger"
   ],
   "scripts": {
-    "test": "xo"
+    "test": "xo",
+    "test:ts": "tsc --noEmit -p test"
   },
   "dependencies": {
     "chalk": "^2.3.2",

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,0 +1,26 @@
+import * as signale from '..';
+
+// Overrides any existing `package.json` config
+signale.config({
+  displayFilename: true,
+  displayTimestamp: true,
+  displayDate: false
+});
+
+signale.success('Hello from the Global scope');
+
+function scopedConfigTest() {
+  // `fooLogger` inherits the config of `signale`
+  const fooLogger = signale.scope('foo scope');
+
+  // Overrides both `signale` and `package.json` configs
+  fooLogger.config({
+    displayFilename: true,
+    displayTimestamp: false,
+    displayDate: true
+  });
+
+  fooLogger.success('Hello from the Local scope');
+}
+
+scopedConfigTest();

--- a/test/custom.ts
+++ b/test/custom.ts
@@ -1,0 +1,27 @@
+import { Signale, SignaleConstructorOptions } from '../';
+
+type CustomLogger = 'remind' | 'santa';
+
+const optionsCustom: SignaleConstructorOptions<CustomLogger> = {
+  stream: process.stdout,
+  scope: 'custom',
+  types: {
+    remind: {
+      badge: '**',
+      color: 'yellow',
+      label: 'reminder'
+    },
+    santa: {
+      badge: '🎅',
+      color: 'red',
+      label: 'santa'
+    }
+  }
+};
+
+const custom = new Signale(optionsCustom);
+
+custom.remind('Improve documentation.');
+custom.santa('Hoho! You have an unused variable on L45.');
+custom.debug('This should still work');
+

--- a/test/default.ts
+++ b/test/default.ts
@@ -1,0 +1,27 @@
+import * as logger1 from '..';
+
+const { Signale } = logger1;
+
+logger1.success('Operation successful');
+logger1.debug('Hello', 'from', 'L59');
+logger1.pending('Write release notes for %s', '1.2.0');
+logger1.fatal(new Error('Unable to acquire lock'));
+logger1.watch('Recursively watching build directory...');
+logger1.complete({
+  prefix: '[task]',
+  message: 'Fix issue #59',
+  suffix: '(@klaussinani)'
+});
+
+const logger2 = new Signale();
+
+logger2.success('Operation successful');
+logger2.debug('Hello', 'from', 'L59');
+logger2.pending('Write release notes for %s', '1.2.0');
+logger2.fatal(new Error('Unable to acquire lock'));
+logger2.watch('Recursively watching build directory...');
+logger2.complete({
+  prefix: '[task]',
+  message: 'Fix issue #59',
+  suffix: '(@klaussinani)'
+});

--- a/test/override.ts
+++ b/test/override.ts
@@ -1,0 +1,26 @@
+import { Signale, SignaleConstructorOptions } from '../';
+
+const optionsOverride: SignaleConstructorOptions = {
+  types: {
+    error: {
+      badge: '!!',
+      color: 'red',
+      label: 'fatal error'
+    },
+    success: {
+      badge: '++',
+      color: 'green',
+      label: 'huge success'
+    }
+  }
+};
+
+const signale = new Signale(optionsOverride);
+
+signale.error('Default Error Log');
+signale.success('Default Success Log');
+
+const customOverride = new Signale(optionsOverride);
+
+customOverride.error('Custom Error Log');
+customOverride.success('Custom Success Log');

--- a/test/scoped.ts
+++ b/test/scoped.ts
@@ -1,0 +1,23 @@
+import { Signale, SignaleConstructorOptions } from '../';
+
+const optionsScope: SignaleConstructorOptions = {
+  scope: 'global1 scope'
+};
+
+const global1 = new Signale(optionsScope);
+global1.success('Successful Operation');
+
+const global2 = global1.scope('global2 scope');
+global2.success('Hello from the global2 scope');
+
+function scopedTest() {
+  const outer = global2.scope('outer', 'scope');
+  outer.success('Hello from the outer scope');
+
+  setTimeout(() => {
+    const inner = outer.scope('inner', 'scope');
+    inner.success('Hello from the inner scope');
+  }, 500);
+}
+
+scopedTest();

--- a/test/secrets.ts
+++ b/test/secrets.ts
@@ -1,0 +1,19 @@
+import { Signale, SignaleConstructorOptions } from '..';
+
+// In reality secrets could be securely fetched/decrypted through a dedicated API
+const [USERNAME, TOKEN] = ['klaussinani', 'token'];
+
+const opts: SignaleConstructorOptions = {
+  secrets: [USERNAME, TOKEN]
+}
+
+const logger1 = new Signale(opts);
+
+logger1.log('$ exporting USERNAME=%s', USERNAME);
+logger1.log('$ exporting TOKEN=%s', TOKEN);
+
+// `logger2` inherits all secrets from its parent `logger1`
+const logger2 = logger1.scope('parent');
+
+logger2.log('$ exporting USERNAME=%s', USERNAME);
+logger2.log('$ exporting TOKEN=%s', TOKEN);

--- a/test/streams.ts
+++ b/test/streams.ts
@@ -1,0 +1,19 @@
+import { Signale, SignaleConstructorOptions } from '..';
+
+const opts: SignaleConstructorOptions = {
+  stream: process.stderr, // All loggers will now write to `process.stderr`
+  types: {
+    error: {
+      badge: '✖',
+      color: 'red',
+      label: 'error',
+      // Only `error` will write to both `process.stdout` & `process.stderr`
+      stream: [process.stdout, process.stderr]
+    }
+  }
+};
+
+const signale = new Signale(opts);
+
+signale.success('Message will appear on `process.stderr`');
+signale.error('Message will appear on both `process.stdout` & `process.stderr`');

--- a/test/timers.ts
+++ b/test/timers.ts
@@ -1,0 +1,13 @@
+import * as signale from '../';
+
+signale.time('test1');
+signale.time('test2');
+signale.time();
+signale.time();
+
+setTimeout(() => {
+  signale.timeEnd();
+  signale.timeEnd();
+  signale.timeEnd('test2');
+  signale.timeEnd('test1');
+}, 500);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+    "target": "ES2017"
+  }
+}


### PR DESCRIPTION
## Description

The PR, a follow-up to #86 and #85, introduces TS ambient type declaration tests as well as new minimal `tsconfig.json` set-up. The testing process can be initialized through the newly added `test:ts` script.