### PR TITLE
Normalize date format of `displayDate` option. Fixes #88 (#84)

### DIFF
--- a/src/signale.js
+++ b/src/signale.js
@@ -55,7 +55,8 @@ class Signale {
   }
 
   get date() {
-    return new Date().toLocaleDateString();
+    const _ = new Date();
+    return [_.getFullYear(), _.getMonth() + 1, _.getDate()].join('-');
   }
 
   get timestamp() {


### PR DESCRIPTION
## Description

The PR normalized the appearance of dates, utilized through the `displayDate` option, to the following global format:

- `YYYY-MM-DD`