### PR TITLE
Normalize time format of `displayTimestamp` option. Fixes #89 (#84)

### DIFF
--- a/src/signale.js
+++ b/src/signale.js
@@ -60,7 +60,8 @@ class Signale {
   }
 
   get timestamp() {
-    return new Date().toLocaleTimeString();
+    const _ = new Date();
+    return [_.getHours(), _.getMinutes(), _.getSeconds()].join(':');
   }
 
   get filename() {


### PR DESCRIPTION
## Description

The PR normalized the appearance of timestamps, utilized through the `displayTimestamp` option, to the following global format:

- `HH:MM:SS`