### PR TITLE
Fix: Minor Readme Duplicate & Update Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signale",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Highly configurable logging utility",
   "license": "MIT",
   "repository": "klaussinani/signale",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "test": "npm run lint && npm run test:ts"
   },
   "dependencies": {
-    "chalk": "^2.3.2",
-    "figures": "^2.0.0",
-    "pkg-conf": "^2.1.0"
+    "chalk": "^4.0.0",
+    "figures": "^3.2.0",
+    "pkg-conf": "^3.1.0"
   },
   "devDependencies": {
-    "@types/node": "^11.11.3",
-    "typescript": "^3.3.3333",
+    "@types/node": "^13.13.5",
+    "typescript": "^3.8.3",
     "xo": "*"
   },
   "options": {

--- a/readme.md
+++ b/readme.md
@@ -271,20 +271,6 @@ The label used to identify the type of the logger.
 
 The color of the label, can be any of the foreground colors supported by [chalk](https://github.com/chalk/chalk#colors).
 
-##### `logLevel`
-
-- Type: `String`
-- Default: `'info'`
-
-The log level corresponding to the logger. Messages originating from the logger are displayed only if the log level is greater or equal to the above described general logging level `logLevel` of the `Signale` instance.
-
-##### `stream`
-
-- Type: `stream.Writable|stream.Writable[]`
-- Default: `process.stdout`
-
-Destination to which the data is written, can be a single valid [Writable stream](https://nodejs.org/api/stream.html#stream_writable_streams) or an array holding multiple valid Writable streams.
-
 ### Scoped Loggers
 
 To create a scoped logger from scratch, define the `scope` field inside the `options` object and pass it as argument to a new signale instance.


### PR DESCRIPTION
Hi,

I spotted a minor but slightly 'large' error in the `readme.md`, specifically 2 `Signale` constructor `options` hash keys were duplicated and documented twice. I've removed the extra lines, and updated all dependencies to latest versions. Currently untested, but `npm run test` fails due to https://github.com/typescript-eslint/typescript-eslint/pull/2010 (fix merged but awaiting release). It should work once `@typescript-eslint` is updated.

### Changes
* [x] minor fix in `readme.md`
* [x] bumped `chalk` from `^2.3.2` to `^4.0.0`
* [x] bumped `figures` from `^2.0.0` to `^3.2.0`
* [x] bumped `pkg-conf` from `^2.1.0` to `^3.1.0`
* [x] bumped package version to `1.4.1`

### TODO
* [ ] verify `yarn test` after `@typescript-eslint` is updated in npm registry