### PR TITLE
Security: Regex injection and potential ReDoS in secret redaction

### DIFF
--- a/src/signale.js
+++ b/src/signale.js
@@ -139,7 +139,12 @@ class Signale {
     let safeMessage = message;
 
     _secrets.forEach(secret => {
-      safeMessage = safeMessage.replace(new RegExp(secret, 'g'), '[secure]');
+      if (secret.length === 0) {
+        return;
+      }
+
+      const escapedSecret = secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      safeMessage = safeMessage.replace(new RegExp(escapedSecret, 'g'), '[secure]');
     });
 
     return safeMessage;


### PR DESCRIPTION
## Problem

Secret values are interpolated directly into `new RegExp(secret, 'g')` without escaping metacharacters. If a secret contains regex syntax (e.g., `.*`, groups, nested quantifiers), redaction behavior can be bypassed, over-broadened, or trigger catastrophic backtracking on crafted inputs, causing CPU spikes and log-path denial of service.

**Severity**: `high`
**File**: `src/signale.js`

## Solution

Escape secrets before building regex patterns (e.g., `secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`), or avoid regex entirely by using safe literal replacement logic. Also guard against empty-string secrets to avoid replacing every position.

## Changes

- `src/signale.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
